### PR TITLE
cpp/CMakeLists.txt: Relax CMake version requirement

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -29,7 +29,7 @@ jobs:
       #
       # To add more build types (Release, Debug, RelWithDebInfo, etc.) customize the build_type list.
       matrix:
-        os: [ubuntu-latest, ubuntu-22.04, ubuntu-24.04, windows-latest]
+        os: [ubuntu-latest, ubuntu-20.04, ubuntu-22.04, ubuntu-24.04, windows-latest]
         build_type: [Release]
         c_compiler: [gcc, clang, cl]
         include:
@@ -40,6 +40,12 @@ jobs:
             c_compiler: gcc
             cpp_compiler: g++
           - os: ubuntu-latest
+            c_compiler: clang
+            cpp_compiler: clang++
+          - os: ubuntu-20.04
+            c_compiler: gcc
+            cpp_compiler: g++
+          - os: ubuntu-20.04
             c_compiler: clang
             cpp_compiler: clang++
           - os: ubuntu-22.04
@@ -60,6 +66,8 @@ jobs:
           - os: windows-latest
             c_compiler: clang
           - os: ubuntu-latest
+            c_compiler: cl
+          - os: ubuntu-20.04
             c_compiler: cl
           - os: ubuntu-22.04
             c_compiler: cl

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.20.2)
+cmake_minimum_required(VERSION 3.16)
 set(CMAKE_VERBOSE_MAKEFILE ON)
 project(SupermarketReceipt VERSION 1.0
         LANGUAGES CXX)


### PR DESCRIPTION
CMake 3.16 is what is provided with Ubuntu 20.04, and it seems to work
just as well as the 3.20 previously required.